### PR TITLE
TDK-12105: Addressing latest ut-core(5.1.0) log level changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ endif
  
 $(info HAL [$(HAL)])
 endif
-  
+
+UT_LOG_LEVEL ?= 4
+
 .PHONY: clean list all
  
 # Here is a list of exports from this makefile to the next
@@ -71,10 +73,10 @@ export CFLAGS
 export TARGET_EXEC
  
 .PHONY: clean list build
- 
+
 build:
 	@echo UT [$@]
-	make -C ./ut-core
+	make -C ./ut-core UT_LOG_LEVEL=$(UT_LOG_LEVEL)
  
 list:
 	@echo UT [$@]

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ NC="\e[39m"
 # When the major version changes in the ut-core, what that signals is that the testings will have to be upgraded to support that version
 # Therefore in that case it warns you but doesnt' chnage to that version, which could cause your tests to break.
 # Change this to upgrade your UT-Core Major versions. Non ABI Changes 1.x.x are supported, between major revisions
-UT_PROJECT_MAJOR_VERSION="3.1.1"
+UT_PROJECT_MAJOR_VERSION="5."
 
 # Clone the Unit Test Requirements
 TEST_REPO=git@github.com:rdkcentral/ut-core.git


### PR DESCRIPTION
Reason for Changes : Enhancements related to latest ut-core version
Validation: via BPI
Risks: None